### PR TITLE
Add in support for quota configuration from config

### DIFF
--- a/.github/workflows/reject_submission.yml
+++ b/.github/workflows/reject_submission.yml
@@ -1,0 +1,29 @@
+# This action is a cronjob that rejects submissions every 30 minutes
+
+name: reject_submission
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  reject:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install challengeutils
+        pip install pyyaml
+
+    - name: Reject Submissions
+      run: |
+        python scripts/reject_submissions.py config.yml --credential ${{ secrets.SYNAPSE_PAT }}

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ The infrastructure is created through cloudformation templates.  Important notes
 On top of the quota checking system that is built into `annotate_note.py`, there has to be some safeguard for making sure that submissions quota the time quota are stopped.  This is because the submission run time check happens within a for loop, it a docker run command happens to be stuck forever, the submission will never be deemed over the quota.  There is a `stop-submission-over-quota` function in `challengeutils`, unfortunately, this function requires a submission view as input and there is a high likelihood that each queue could have a different runtime.  Therefore, we will not be using this function.
 
 ```
-
+python scripts/reject_submissions.py config.yml
 ```
 
 ### Orchestrator workflow

--- a/annotate_note.cwl
+++ b/annotate_note.cwl
@@ -21,6 +21,8 @@ inputs:
     type: File
   - id: annotator_type
     type: string
+  - id: quota
+    type: int
 
 arguments: 
   - valueFrom: $(inputs.docker_script.path)
@@ -32,6 +34,8 @@ arguments:
     prefix: -i
   - valueFrom: $(inputs.annotator_type)
     prefix: -a
+  - valueFrom: $(inputs.quota)
+    prefix: -q
 
 requirements:
   - class: InitialWorkDirRequirement

--- a/annotate_note.py
+++ b/annotate_note.py
@@ -116,7 +116,7 @@ def main(syn, args):
     start = time.time()
     for note in data_notes_dict:
         # Check that runtime is less than 2 hours (7200 seconds)
-        check_runtime(start, container, container.image, 7200)
+        check_runtime(start, container, container.image, args.quota)
         # noteid = note.pop("identifier")
         exec_cmd = [
             #"curl", "-o", "/output/annotations.json", "-X", "POST",
@@ -198,6 +198,8 @@ if __name__ == '__main__':
                         help="credentials file")
     parser.add_argument("-a", "--annotator_type", required=True,
                         help="Annotation Type")
+    parser.add_argument("-q", "--quota", type=int, default=7200,
+                        help="Max runtime quota in seconds")
     args = parser.parse_args()
     syn = synapseclient.Synapse(configPath=args.synapse_config)
     syn.login()

--- a/config.yml
+++ b/config.yml
@@ -6,6 +6,7 @@
   submit_to:
     - "9614719"  # MCW
   center: SAGEBIO
+  submission_viewid: syn23747126
   # test: false
   # goldstandard: null
 9614654:  # Date Annotator - Test
@@ -17,6 +18,7 @@
     - "9614719"  # MCW
     - "9614757"  # SAGEBIO Test
   center: SAGEBIO
+  submission_viewid: syn23512270
   # test: true
   # goldstandard: null
 9614657:  # Person Name Annotator
@@ -27,6 +29,7 @@
   submit_to:
     - "9614720"  # MCW
   center: SAGEBIO
+  submission_viewid: syn23747126
   # test: false
   # goldstandard: null
 9614685:  # Person Name Annotator - Test
@@ -37,6 +40,7 @@
   submit_to:
     - "9614720"  # MCW
   center: SAGEBIO
+  submission_viewid: syn23512270
   # test: true
   # goldstandard: null
 9614658:  # Physical Address Annotator
@@ -47,6 +51,7 @@
   submit_to:
     - "9614721"  # MCW
   center: SAGEBIO
+  submission_viewid: syn23747126
   # test: false
   # goldstandard: null
 9614684: # Physical Address Annotator - Test
@@ -57,6 +62,7 @@
   submit_to:
     - "9614721"  # MCW
   center: SAGEBIO
+  submission_viewid: syn23512270
   # test: true
   # goldstandard: null
 9614719: # MCW - Date Annotator
@@ -66,6 +72,7 @@
   # question: Date Annotator
   submit_to: null
   center: SAGEBIO
+  submission_viewid: syn25582644
   # test: false
   # goldstandard: null
 9614757: # SAGEBIO - Date Annotator Test
@@ -75,6 +82,7 @@
   # question: Date Annotator
   submit_to: null
   center: SAGEBIO
+  submission_viewid: syn25584929
   # test: false
   # goldstandard: null
 9614720: # MCW - Person Name Annotator
@@ -84,6 +92,7 @@
   # question: Person Name Annotator
   submit_to: null
   center: MCW
+  submission_viewid: syn25582644
   # test: false
   # goldstandard: null
 9614721: # MCW - Physical Address Annotator
@@ -93,5 +102,6 @@
   # question: Physical Address Annotator
   submit_to: null
   center: MCW
+  submission_viewid: syn25582644
   # test: false
   # goldstandard: null

--- a/config.yml
+++ b/config.yml
@@ -88,7 +88,7 @@
   runtime: 7200
   # question: Date Annotator
   submit_to: null
-  center: SAGEBIO
+  center: MCW
   submission_viewid: syn25582644
   datanode_endpoint: http://141.106.224.48:8080/api/v1/
   # test: false

--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,7 @@
 9614652:  # Date Annotator
   dataset_name: 2014-i2b2
   dataset_version: "20201203"
-  runtime: 7200
+  runtime: 7200  # in seconds
   # question: Date Annotator
   submit_to:
     - "9614719"  # MCW

--- a/config.yml
+++ b/config.yml
@@ -78,7 +78,7 @@
   # question: Date Annotator
   submit_to: null
   center: SAGEBIO
-  submission_viewid: syn25582644
+  submission_viewid: syn25584929
   datanode_endpoint: http://10.255.21.50/api/v1/
   # test: false
   # goldstandard: null
@@ -89,7 +89,7 @@
   # question: Date Annotator
   submit_to: null
   center: SAGEBIO
-  submission_viewid: syn25584929
+  submission_viewid: syn25582644
   datanode_endpoint: http://141.106.224.48:8080/api/v1/
   # test: false
   # goldstandard: null

--- a/get_config.cwl
+++ b/get_config.cwl
@@ -32,9 +32,10 @@ requirements:
 
           with open(args.config) as yaml_file:
             config = yaml.load(yaml_file)
-
+          queue_config = config[args.queue]
+          queue_config['submission_status'] = "EVALUATION_IN_PROGRESS"
           with open(args.results, 'w') as json_file:
-            json_file.write(json.dumps(config[args.queue]))
+            json_file.write(json.dumps(queue_config))
 
 inputs:
   - id: configuration

--- a/scripts/reject_submissions.py
+++ b/scripts/reject_submissions.py
@@ -4,16 +4,13 @@ Reject submissions that are invalid in internal queues
 import argparse
 import time
 
-import challengeutils
 from challengeutils.submission import (
     WORKFLOW_LAST_UPDATED_KEY,
     WORKFLOW_START_KEY,
     TIME_REMAINING_KEY,
 )
 from challengeutils.annotations import update_submission_status
-from challengeutils.utils import (evaluation_queue_query,
-                                  update_single_submission_status)
-import pandas as pd
+from challengeutils.utils import update_single_submission_status
 import synapseclient
 from synapseclient.core.retry import with_retry
 from synapseclient import Synapse

--- a/workflow.cwl
+++ b/workflow.cwl
@@ -80,6 +80,7 @@ steps:
       - id: submit_to_queue
       - id: config
       - id: dataset_id
+      - id: runtime
 
   annotate_evaluation_config:
     run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v3.1/cwl/annotate_submission.cwl
@@ -340,6 +341,8 @@ steps:
         source: "#list_clinical_notes/notes"
       - id: annotator_type
         source: "#determine_annotator_type/annotator_type"
+      - id: quota
+        source: "#get_evaluation_config/runtime"
       - id: docker_script
         default:
           class: File


### PR DESCRIPTION
- This also add in the reject submission script which will stop submissions that are over the runtime quota separate from the workflow.
- Reject submissions that are invalid from the internal queues.
- FIxes #60 