### PR TITLE
Execute the API endpoint once prior to actual annotation

### DIFF
--- a/annotate_note.py
+++ b/annotate_note.py
@@ -115,6 +115,26 @@ def main(syn, args):
     }
 
     all_annotations = []
+    # HACK: Run one note annotation first
+    try:
+        exec_cmd = [
+            #"curl", "-o", "/output/annotations.json", "-X", "POST",
+            "curl", "-s", "-X", "POST",
+            f"http://{container_ip}:8080/api/v1/{api_url_map[args.annotator_type]}", "-H",
+            "accept: application/json",
+            "-H", "Content-Type: application/json", "-d",
+            json.dumps({"note": data_notes_dict[0]})
+        ]
+        curl_name = f"{args.submissionid}_curl_{random.randint(10, 1000)}"
+        annotate_note = client.containers.run(
+            "curlimages/curl:7.73.0", exec_cmd,
+            # volumes=volumes,
+            name=curl_name,
+            network="submission", stderr=True
+            # auto_remove=True
+        )
+    except Exception:
+        pass
     # Get annotation start time
     start = time.time()
     for note in data_notes_dict:

--- a/annotate_note.py
+++ b/annotate_note.py
@@ -126,7 +126,7 @@ def main(syn, args):
             json.dumps({"note": data_notes_dict[0]})
         ]
         curl_name = f"{args.submissionid}_curl_{random.randint(10, 1000)}"
-        annotate_note = client.containers.run(
+        client.containers.run(
             "curlimages/curl:7.73.0", exec_cmd,
             # volumes=volumes,
             name=curl_name,


### PR DESCRIPTION
* This is because sometimes the training isn't started until the API endpoint is pinged at least once, which then creates a timeout issue from the endpoint