### PR TITLE
When an error is raised, the traceback is returned - hence still returning notes

### DIFF
--- a/annotate_note.py
+++ b/annotate_note.py
@@ -5,6 +5,7 @@ import json
 import os
 import random
 import time
+import sys
 
 import docker
 import synapseclient
@@ -115,6 +116,8 @@ def main(syn, args):
     }
 
     all_annotations = []
+    # Set traceback to be 0 so nothing is returned
+    sys.trackbacklimit = 0
     # HACK: Run one note annotation first
     try:
         exec_cmd = [


### PR DESCRIPTION
https://stackoverflow.com/questions/17784849/print-an-error-message-without-printing-a-traceback-and-close-the-program-when-a/21556806#21556806